### PR TITLE
feat: Support overrides

### DIFF
--- a/cmd/breaking.go
+++ b/cmd/breaking.go
@@ -21,9 +21,8 @@ import (
 )
 
 var (
-	oldSchemaFilename string
-	newSchemaFilename string
-	overridesSchemaFilename string
+	oldSchemaFilenames []string
+	newSchemaFilenames []string
 	cuePath           string
 )
 
@@ -34,7 +33,7 @@ var breakingCmd = &cobra.Command{
 	Long:          `Validate if a schema change is backwards-compatible.`,
 	SilenceErrors: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := RunBreakingChangeDetection(oldSchemaFilename, newSchemaFilename, overridesSchemaFilename, cuePath)
+		err := RunBreakingChangeDetection(oldSchemaFilenames, newSchemaFilenames, cuePath)
 		if err != nil {
 			printError(err)
 			os.Exit(1)
@@ -42,46 +41,36 @@ var breakingCmd = &cobra.Command{
 	},
 }
 
-func RunBreakingChangeDetection(oldSchemaFilename string, newSchemaFilename string, overridesSchemaFilename string, cuePath string) error {
+func RunBreakingChangeDetection(oldSchemaFilenames []string, newSchemaFilenames []string, cuePath string) error {
 	ctx := cuecontext.New()
 
-	oldValue := loadSchema(ctx, oldSchemaFilename, cuePath)
+	oldValue := loadSchemas(ctx, oldSchemaFilenames, cuePath)
 	if err := oldValue.Err(); err != nil {
 		return err
-	}
-	newValue := loadSchema(ctx, newSchemaFilename, cuePath)
+	}	
+
+	newValue := loadSchemas(ctx, newSchemaFilenames, cuePath)
 	if err := newValue.Err(); err != nil {
 		return err
 	}
-	overridesValue := ctx.CompileString("_")
-	if overridesSchemaFilename != "" {
-		overridesValue := loadSchema(ctx, overridesSchemaFilename, cuePath)
-		if err := overridesValue.Err(); err != nil {
-			return err
-		}
-	}
 
-	return IsBackwardsCompatible(oldValue, newValue, overridesValue)
+	return IsBackwardsCompatible(oldValue, newValue)
 }
 
-func IsBackwardsCompatible(oldValue cue.Value, newValue cue.Value, overridesValue cue.Value) error {
-	overriddenOldValue := oldValue.Unify(overridesValue)
-	return newValue.Subsume(overriddenOldValue)
+func IsBackwardsCompatible(oldValue cue.Value, newValue cue.Value) error {
+	return newValue.Subsume(oldValue)
 }
 
 func init() {
 	rootCmd.AddCommand(breakingCmd)
 
-	breakingCmd.Flags().StringVar(&oldSchemaFilename, "old", "", "old CUE schema file")
+	breakingCmd.Flags().StringArrayVar(&oldSchemaFilenames, "old", []string{}, "old CUE schema files")
 	breakingCmd.MarkFlagRequired("old")
 	breakingCmd.MarkFlagFilename("old", "cue")
 
-	breakingCmd.Flags().StringVar(&newSchemaFilename, "new", "", "new CUE schema file")
+	breakingCmd.Flags().StringArrayVar(&newSchemaFilenames, "new", []string{}, "new CUE schema files")
 	breakingCmd.MarkFlagRequired("new")
 	breakingCmd.MarkFlagFilename("new", "cue")
-
-	breakingCmd.Flags().StringVar(&overridesSchemaFilename, "overrides", "", "overrides CUE schema file")
-	breakingCmd.MarkFlagFilename("overrides", "cue")
 
 	breakingCmd.Flags().StringVar(&cuePath, "path", "", "CUE path that contains the schema to validate in the CUE files")
 }
@@ -95,6 +84,17 @@ func loadSchema(ctx *cue.Context, filename string, cuePath string) cue.Value {
 	rootValue := ctx.BuildInstance(insts[0])
 
 	return rootValue.LookupPath(cue.ParsePath(cuePath))
+}
+
+func loadSchemas(ctx *cue.Context, filenames []string, cuePath string) cue.Value {
+	value := ctx.CompileString("_")
+	for _, filename := range(filenames) {
+		value = value.Unify(loadSchema(ctx, filename, cuePath))
+		if err := value.Err(); err != nil {
+			return value
+		}	
+	}
+	return value
 }
 
 func printError(err error) {

--- a/cmd/breaking_test.go
+++ b/cmd/breaking_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"cmp"
 	"strconv"
 	"testing"
 
@@ -13,6 +14,7 @@ func TestBreakingChange(t *testing.T) {
 		compatible bool
 		old        string
 		new        string
+		override   string
 	}
 
 	testCases := []breakingChangeTest{
@@ -20,20 +22,24 @@ func TestBreakingChange(t *testing.T) {
 		0: {compatible: true, old: `#schema: messages: {}`, new: `#schema: messages: foo?: string`},
 		// Remove message is not compatible
 		1: {compatible: false, old: `#schema: messages: foo?: string`, new: `#schema: messages: {}`},
+		// Remove message with override is compatible
+		2: {compatible: true, old: `#schema: messages: foo?: string`, new: `#schema: messages: {}`, override: `#schema: messages: foo: _|_`},
 		// Add new enum option is compatible
-		2: {compatible: true, old: `#schema: enums: enum1: { value1?: 1}`, new: `#schema: enums: enum1: {value1?: 1, value2?: 2}`},
+		3: {compatible: true, old: `#schema: enums: enum1: { value1?: 1}`, new: `#schema: enums: enum1: {value1?: 1, value2?: 2}`},
 		// Removing an enum option is not compatible
-		3: {compatible: false, old: `#schema: enums: enum1: { value1?: 1, value2?: 2}`, new: `#schema: enums: enum1: {value1?: 1}`},
+		4: {compatible: false, old: `#schema: enums: enum1: { value1?: 1, value2?: 2}`, new: `#schema: enums: enum1: {value1?: 1}`},
+		// Removing an enum option is not compatible except with an override
+		5: {compatible: true, old: `#schema: enums: enum1: { value1?: 1, value2?: 2}`, new: `#schema: enums: enum1: {value1?: 1}`, override: `#schema: enums: enum1: {value1?: 1, value2: _|_}`},
 		// Adding an optional field to a message is compatible
-		4: {compatible: true, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2?: int}`},
+		6: {compatible: true, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2?: int}`},
 		// Adding a required field to a message is not compatible
-		5: {compatible: false, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2: int}`},
+		7: {compatible: false, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2: int}`},
 		// Removing an optional field from a message is not compatible
-		6: {compatible: false, old: `#schema: messages: message1?: { field1: int, field2?: int}`, new: `#schema: messages: message1?: { field1: int }`},
+		8: {compatible: false, old: `#schema: messages: message1?: { field1: int, field2?: int}`, new: `#schema: messages: message1?: { field1: int }`},
 		// Removing a required field from a message is not compatible
-		7: {compatible: false, old: `#schame: messages: message1?: { field1: int, field2: int}`, new: `#schema: messages: message1?: { field1: int }`},
+		9: {compatible: false, old: `#schame: messages: message1?: { field1: int, field2: int}`, new: `#schema: messages: message1?: { field1: int }`},
 		// Defining enums when they weren't defined before is compatible
-		8: {compatible: true, old: `#schema: messages: {}`, new: `#schema: { messages: {}, enums?: enum1: {value1?: 1 } }`},
+		10: {compatible: true, old: `#schema: messages: {}`, new: `#schema: { messages: {}, enums?: enum1: {value1?: 1 } }`},
 	}
 
 	for i, tc := range testCases {
@@ -42,16 +48,20 @@ func TestBreakingChange(t *testing.T) {
 		}
 
 		key := tc.old + " ⊑ " + tc.new
+		if tc.override != "" {
+			key = key + " (w/ override) " + tc.override
+		}
 		t.Run(strconv.Itoa(i)+"/"+key, func(t *testing.T) {
 			ctx := cuecontext.New()
 			oldValue := ctx.CompileString(tc.old)
 			newValue := ctx.CompileString(tc.new)
+			overrideValue := ctx.CompileString(cmp.Or(tc.override, "_"))
 
-			err := cmd.IsBackwardsCompatible(oldValue, newValue)
+			err := cmd.IsBackwardsCompatible(oldValue, newValue, overrideValue)
 			got := err == nil
 
 			if got != tc.compatible {
-				t.Errorf(`IsBackwardsCompatible(%q, %q) = %v, want %v; (err = %v)`, tc.old, tc.new, got, tc.compatible, err)
+				t.Errorf(`IsBackwardsCompatible(%q, %q, %q) = %v, want %v; (err = %v)`, tc.old, tc.new, tc.override, got, tc.compatible, err)
 			}
 		})
 	}

--- a/cmd/breaking_test.go
+++ b/cmd/breaking_test.go
@@ -28,17 +28,19 @@ func TestBreakingChange(t *testing.T) {
 		// Removing an enum option is not compatible
 		4: {compatible: false, old: `#schema: enums: enum1: { value1?: 1, value2?: 2}`, new: `#schema: enums: enum1: {value1?: 1}`},
 		// Removing an enum option is not compatible except with an override
-		5: {compatible: true, old: `#schema: enums: enum1: { value1?: 1, value2?: 2}`, new: `#schema: enums: enum1: {value1?: 1}`, override: `#schema: enums: enum1: {value1?: 1, value2: _|_}`},
+		5: {compatible: true, old: `#schema: enums: enum1: { value1?: 1, value2?: 2}`, new: `#schema: enums: enum1: {value1?: 1}`, override: `#schema: enums: enum1: {value2: _|_}`},
+		// Renaming an enum option is not compatible except with an override
+		6: {compatible: true, old: `#schema: enums: enum1: { value1?: 1, value2?: 2}`, new: `#schema: enums: enum1: {value1?: 1, value3?: 2}`, override: `#schema: enums: enum1: {value2: _|_}`},
 		// Adding an optional field to a message is compatible
-		6: {compatible: true, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2?: int}`},
+		7: {compatible: true, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2?: int}`},
 		// Adding a required field to a message is not compatible
-		7: {compatible: false, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2: int}`},
+		8: {compatible: false, old: `#schema: messages: message1?: { field1: int }`, new: `#schema: messages: message1?: { field1: int, field2: int}`},
 		// Removing an optional field from a message is not compatible
-		8: {compatible: false, old: `#schema: messages: message1?: { field1: int, field2?: int}`, new: `#schema: messages: message1?: { field1: int }`},
+		9: {compatible: false, old: `#schema: messages: message1?: { field1: int, field2?: int}`, new: `#schema: messages: message1?: { field1: int }`},
 		// Removing a required field from a message is not compatible
-		9: {compatible: false, old: `#schame: messages: message1?: { field1: int, field2: int}`, new: `#schema: messages: message1?: { field1: int }`},
+		10: {compatible: false, old: `#schame: messages: message1?: { field1: int, field2: int}`, new: `#schema: messages: message1?: { field1: int }`},
 		// Defining enums when they weren't defined before is compatible
-		10: {compatible: true, old: `#schema: messages: {}`, new: `#schema: { messages: {}, enums?: enum1: {value1?: 1 } }`},
+		111: {compatible: true, old: `#schema: messages: {}`, new: `#schema: { messages: {}, enums?: enum1: {value1?: 1 } }`},
 	}
 
 	for i, tc := range testCases {

--- a/cmd/breaking_test.go
+++ b/cmd/breaking_test.go
@@ -1,7 +1,6 @@
 package cmd_test
 
 import (
-	"cmp"
 	"strconv"
 	"testing"
 
@@ -55,9 +54,11 @@ func TestBreakingChange(t *testing.T) {
 			ctx := cuecontext.New()
 			oldValue := ctx.CompileString(tc.old)
 			newValue := ctx.CompileString(tc.new)
-			overrideValue := ctx.CompileString(cmp.Or(tc.override, "_"))
+			if tc.override != "" {
+				oldValue = oldValue.Unify(ctx.CompileString(tc.override))
+			}
 
-			err := cmd.IsBackwardsCompatible(oldValue, newValue, overrideValue)
+			err := cmd.IsBackwardsCompatible(oldValue, newValue)
 			got := err == nil
 
 			if got != tc.compatible {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	golang.org/x/text v0.22.0
 )
 
-replace cuelang.org/go v0.12.0 => github.com/GrahamDennis/cue v0.0.0-20250329053811-d50ef8cddeaf
+replace cuelang.org/go v0.12.0 => github.com/GrahamDennis/cue v0.0.0-20250412044858-d27ca9c98eb2
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20250304105642-27e071d2c9b1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cuelabs.dev/go/oci/ociregistry v0.0.0-20250304105642-27e071d2c9b1 h1:Dmbd5Q+ENb2C6carvwrMsrOUwJ9X9qfL5JdW32gYAHo=
 cuelabs.dev/go/oci/ociregistry v0.0.0-20250304105642-27e071d2c9b1/go.mod h1:dqrnoZx62xbOZr11giMPrWbhlaV8euHwciXZEy3baT8=
-github.com/GrahamDennis/cue v0.0.0-20250329053811-d50ef8cddeaf h1:ZTfCs+z1QIw/X7QBdyfiWg0QuCFfSqysfmChIiS5/cs=
-github.com/GrahamDennis/cue v0.0.0-20250329053811-d50ef8cddeaf/go.mod h1:TbjbLY3H7gYWvEPYtV7EGm1+Ey/gU05/m2bMx1YIN9E=
+github.com/GrahamDennis/cue v0.0.0-20250412044858-d27ca9c98eb2 h1:WKKZZZpUfuQp/ffv+29cINwDWP+4Gx9mvz/Y67v5aSk=
+github.com/GrahamDennis/cue v0.0.0-20250412044858-d27ca9c98eb2/go.mod h1:TbjbLY3H7gYWvEPYtV7EGm1+Ey/gU05/m2bMx1YIN9E=
 github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/package.nix
+++ b/package.nix
@@ -10,5 +10,5 @@
         ./main.go
       ];
     };
-    vendorHash = "sha256-F2RRkU1Nxp8euh1b4iDYbYgQRP7A/4wB0mYyimH4J20=";
+    vendorHash = "sha256-RbaaxFtUPp8oaK0XS3g07XWz2MQkx4uAi8tGFND2Lhk=";
 }


### PR DESCRIPTION
If you need to perform a change that is technically breaking but still permit it, `cue-schema` now permits multiple old and/or new schemas to be supplied, and all schemas of a given type will be unified together.

This provides some partial ability to override breaking changes. For example typically removing / redefining an enum field would be invalid:

Old:

```cue
#schema: enums: enum1: { value1?: 1, value2?: 2}
```

New:

```cue
#schema: enums: enum1: { value1?: 1 }
```

However by supplying an extra old schema, this can be made valid:

```cue
// mark value2 as bottom (forbidden)
#schema: enums: enum1: { value2: _|_ }
```
